### PR TITLE
Add focus border mode for active tasks

### DIFF
--- a/app/controllers/overlay_controller.py
+++ b/app/controllers/overlay_controller.py
@@ -1,3 +1,5 @@
+from PyQt6.QtWidgets import QApplication
+
 from app.widgets.focus_border_widget import FocusBorderWidget
 
 
@@ -6,13 +8,46 @@ class OverlayController:
         self.parent = parent
         self.app = app
 
-        self.focus_border = FocusBorderWidget(
-            on_close_callback=self.on_focus_border_closed
-        )
-        self.focus_border.hide()
+        self.focus_borders = []
+        self._create_focus_borders()
 
         self.app.data.app_events.timer_started.connect(self.display_overlay)
         self.app.data.app_events.timer_paused.connect(self.hide_overlay)
+
+        qapp = QApplication.instance()
+        if qapp:
+            qapp.screenAdded.connect(self._handle_screen_added)
+            qapp.screenRemoved.connect(self._handle_screen_removed)
+
+    def _create_focus_borders(self):
+        for border in self.focus_borders:
+            border.hide()
+            border.deleteLater()
+        self.focus_borders.clear()
+
+        screens = QApplication.screens()
+        for screen in screens:
+            border = FocusBorderWidget(
+                on_close_callback=self.on_focus_border_closed, target_screen=screen
+            )
+            border.hide()
+            self.focus_borders.append(border)
+
+    def _handle_screen_added(self, screen):
+        border = FocusBorderWidget(
+            on_close_callback=self.on_focus_border_closed, target_screen=screen
+        )
+        border.hide()
+        self.focus_borders.append(border)
+
+    def _handle_screen_removed(self, screen):
+        borders_to_remove = [
+            b for b in self.focus_borders if b._target_screen == screen
+        ]
+        for border in borders_to_remove:
+            border.hide()
+            border.deleteLater()
+            self.focus_borders.remove(border)
 
     def resize(self, event_size):
         pass
@@ -20,14 +55,17 @@ class OverlayController:
     def display_overlay(self):
         top_task = self.app.data.get_top_task()
         if not top_task:
-            self.focus_border.hide()
+            for border in self.focus_borders:
+                border.hide()
             return
-        self.focus_border.set_task_name(top_task.task_title)
-        self.focus_border.show()
+        for border in self.focus_borders:
+            border.set_task_name(top_task.task_title)
+            border.show()
         self.parent.hide()
 
     def hide_overlay(self):
-        self.focus_border.hide()
+        for border in self.focus_borders:
+            border.hide()
         self.parent.show()
 
     def on_focus_border_closed(self):

--- a/app/controllers/overlay_controller.py
+++ b/app/controllers/overlay_controller.py
@@ -1,4 +1,4 @@
-from app.widgets.overlay_widget import Overlay
+from app.widgets.focus_border_widget import FocusBorderWidget
 
 
 class OverlayController:
@@ -6,23 +6,29 @@ class OverlayController:
         self.parent = parent
         self.app = app
 
-        self.overlay = Overlay(self.parent.lst_tasks)
-        self.overlay.hide()
+        self.focus_border = FocusBorderWidget(
+            on_close_callback=self.on_focus_border_closed
+        )
+        self.focus_border.hide()
 
-        # app events
         self.app.data.app_events.timer_started.connect(self.display_overlay)
         self.app.data.app_events.timer_paused.connect(self.hide_overlay)
 
     def resize(self, event_size):
-        self.overlay.resize(event_size)
+        pass
 
     def display_overlay(self):
         top_task = self.app.data.get_top_task()
         if not top_task:
-            self.overlay.hide()
+            self.focus_border.hide()
             return
-        self.overlay.setTitle(top_task.task_title)
-        self.overlay.show()
+        self.focus_border.set_task_name(top_task.task_title)
+        self.focus_border.show()
+        self.parent.hide()
 
     def hide_overlay(self):
-        self.overlay.hide()
+        self.focus_border.hide()
+        self.parent.show()
+
+    def on_focus_border_closed(self):
+        self.hide_overlay()

--- a/app/controllers/overlay_controller.py
+++ b/app/controllers/overlay_controller.py
@@ -31,4 +31,8 @@ class OverlayController:
         self.parent.show()
 
     def on_focus_border_closed(self):
-        self.hide_overlay()
+        if (
+            hasattr(self.parent, "manage_timer_controller")
+            and self.parent.manage_timer_controller.timer_on
+        ):
+            self.parent.manage_timer_controller.toggle_timer()

--- a/app/widgets/focus_border_widget.py
+++ b/app/widgets/focus_border_widget.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import Qt, QRect
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPainter, QColor, QPen, QFont
 from PyQt6.QtWidgets import QWidget, QPushButton, QApplication, QHBoxLayout, QLabel
 
@@ -16,6 +16,7 @@ class FocusBorderWidget(QWidget):
 
         self.border_color = QColor(0, 122, 255)
         self.border_width = 8
+        self.top_border_width = 45
         self.task_name = ""
         self.on_close_callback = on_close_callback
 
@@ -89,7 +90,7 @@ class FocusBorderWidget(QWidget):
             screen_geometry = screen.geometry()
             header_width = self.header_widget.sizeHint().width()
             x = (screen_geometry.width() - header_width) // 2
-            y = self.border_width + 5
+            y = self.top_border_width + 5
             self.header_widget.move(x, y)
 
     def showEvent(self, event):
@@ -101,17 +102,24 @@ class FocusBorderWidget(QWidget):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         rect = self.rect()
-        border_rect = QRect(
-            rect.x() + self.border_width // 2,
-            rect.y() + self.border_width // 2,
-            rect.width() - self.border_width,
-            rect.height() - self.border_width,
-        )
+        QPen(self.border_color)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(self.border_color)
 
-        pen = QPen(self.border_color)
-        pen.setWidth(self.border_width)
-        painter.setPen(pen)
-        painter.drawRect(border_rect)
+        painter.drawRect(rect.x(), rect.y(), rect.width(), self.top_border_width)
+        painter.drawRect(rect.x(), rect.y(), self.border_width, rect.height())
+        painter.drawRect(
+            rect.x(),
+            rect.y() + rect.height() - self.border_width,
+            rect.width(),
+            self.border_width,
+        )
+        painter.drawRect(
+            rect.x() + rect.width() - self.border_width,
+            rect.y(),
+            self.border_width,
+            rect.height(),
+        )
 
         painter.end()
 

--- a/app/widgets/focus_border_widget.py
+++ b/app/widgets/focus_border_widget.py
@@ -1,3 +1,5 @@
+import sys
+
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPainter, QColor, QPen, QFont
 from PyQt6.QtWidgets import QWidget, QPushButton, QApplication, QHBoxLayout, QLabel
@@ -19,12 +21,55 @@ class FocusBorderWidget(QWidget):
         self.top_border_width = 45
         self.task_name = ""
         self.on_close_callback = on_close_callback
+        self._macos_properties_set = False
 
         self._setup_header()
 
         screen = QApplication.primaryScreen()
         if screen:
             self.setGeometry(screen.geometry())
+
+    def _setup_macos_window_properties(self):
+        if self._macos_properties_set:
+            return
+        if sys.platform != "darwin":
+            return
+
+        try:
+            from ctypes import c_void_p, CDLL, c_bool, c_uint
+
+            NSWindowCollectionBehaviorCanJoinAllSpaces = 1 << 0
+            NSWindowCollectionBehaviorFullScreenAuxiliary = 1 << 8
+
+            view_id = int(self.winId())
+
+            objc = CDLL(None)
+            objc.objc_getClass.restype = c_void_p
+            objc.sel_registerName.restype = c_void_p
+
+            send_msg = objc.objc_msgSend
+            send_msg.restype = c_void_p
+            send_msg.argtypes = [c_void_p, c_void_p]
+
+            window_sel = objc.sel_registerName(b"window")
+            window = send_msg(view_id, window_sel)
+
+            if window:
+                self._macos_properties_set = True
+
+                set_hides_sel = objc.sel_registerName(b"setHidesOnDeactivate:")
+                send_msg.argtypes = [c_void_p, c_void_p, c_bool]
+                send_msg(window, set_hides_sel, False)
+
+                collection_behavior = (
+                    NSWindowCollectionBehaviorCanJoinAllSpaces
+                    | NSWindowCollectionBehaviorFullScreenAuxiliary
+                )
+                set_cb_sel = objc.sel_registerName(b"setCollectionBehavior:")
+                send_msg.argtypes = [c_void_p, c_void_p, c_uint]
+                send_msg(window, set_cb_sel, collection_behavior)
+        except Exception:
+            pass
 
     def _setup_header(self):
         self.header_widget = QWidget(self)
@@ -40,12 +85,14 @@ class FocusBorderWidget(QWidget):
         font.setPointSize(18)
         font.setBold(True)
         self.task_label.setFont(font)
-        self.task_label.setStyleSheet("""
+        self.task_label.setStyleSheet(
+            """
             color: white;
             background-color: rgba(0, 0, 0, 0.7);
             border-radius: 8px;
             padding: 8px 16px;
-        """)
+        """
+        )
         layout.addWidget(self.task_label)
 
         self.close_button = QPushButton("✕", self.header_widget)
@@ -95,6 +142,7 @@ class FocusBorderWidget(QWidget):
 
     def showEvent(self, event):
         super().showEvent(event)
+        self._setup_macos_window_properties()
         self._position_header()
 
     def paintEvent(self, event):

--- a/app/widgets/focus_border_widget.py
+++ b/app/widgets/focus_border_widget.py
@@ -39,7 +39,12 @@ class FocusBorderWidget(QWidget):
         font.setPointSize(18)
         font.setBold(True)
         self.task_label.setFont(font)
-        self.task_label.setStyleSheet("color: white; background-color: transparent;")
+        self.task_label.setStyleSheet("""
+            color: white;
+            background-color: rgba(0, 0, 0, 0.7);
+            border-radius: 8px;
+            padding: 8px 16px;
+        """)
         layout.addWidget(self.task_label)
 
         self.close_button = QPushButton("✕", self.header_widget)

--- a/app/widgets/focus_border_widget.py
+++ b/app/widgets/focus_border_widget.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import QWidget, QPushButton, QApplication, QHBoxLayout, QLa
 
 
 class FocusBorderWidget(QWidget):
-    def __init__(self, on_close_callback=None):
+    def __init__(self, on_close_callback=None, target_screen=None):
         super().__init__()
         self.setWindowFlags(
             Qt.WindowType.FramelessWindowHint
@@ -22,10 +22,11 @@ class FocusBorderWidget(QWidget):
         self.task_name = ""
         self.on_close_callback = on_close_callback
         self._macos_properties_set = False
+        self._target_screen = target_screen
 
         self._setup_header()
 
-        screen = QApplication.primaryScreen()
+        screen = target_screen if target_screen else QApplication.primaryScreen()
         if screen:
             self.setGeometry(screen.geometry())
 
@@ -132,7 +133,9 @@ class FocusBorderWidget(QWidget):
         self._position_header()
 
     def _position_header(self):
-        screen = QApplication.primaryScreen()
+        screen = (
+            self._target_screen if self._target_screen else QApplication.primaryScreen()
+        )
         if screen:
             screen_geometry = screen.geometry()
             header_width = self.header_widget.sizeHint().width()
@@ -140,12 +143,12 @@ class FocusBorderWidget(QWidget):
             y = self.top_border_width + 5
             self.header_widget.move(x, y)
 
-    def showEvent(self, event):
-        super().showEvent(event)
+    def showEvent(self, a0):
+        super().showEvent(a0)
         self._setup_macos_window_properties()
         self._position_header()
 
-    def paintEvent(self, event):
+    def paintEvent(self, a0):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
@@ -171,6 +174,6 @@ class FocusBorderWidget(QWidget):
 
         painter.end()
 
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
+    def resizeEvent(self, a0):
+        super().resizeEvent(a0)
         self._position_header()

--- a/app/widgets/focus_border_widget.py
+++ b/app/widgets/focus_border_widget.py
@@ -1,0 +1,115 @@
+from PyQt6.QtCore import Qt, QRect
+from PyQt6.QtGui import QPainter, QColor, QPen, QFont
+from PyQt6.QtWidgets import QWidget, QPushButton, QApplication, QHBoxLayout, QLabel
+
+
+class FocusBorderWidget(QWidget):
+    def __init__(self, on_close_callback=None):
+        super().__init__()
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+
+        self.border_color = QColor(0, 122, 255)
+        self.border_width = 8
+        self.task_name = ""
+        self.on_close_callback = on_close_callback
+
+        self._setup_header()
+
+        screen = QApplication.primaryScreen()
+        if screen:
+            self.setGeometry(screen.geometry())
+
+    def _setup_header(self):
+        self.header_widget = QWidget(self)
+        self.header_widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        layout = QHBoxLayout(self.header_widget)
+        layout.setContentsMargins(20, 10, 20, 10)
+
+        layout.addStretch()
+
+        self.task_label = QLabel(self.header_widget)
+        font = QFont()
+        font.setPointSize(18)
+        font.setBold(True)
+        self.task_label.setFont(font)
+        self.task_label.setStyleSheet("color: white; background-color: transparent;")
+        layout.addWidget(self.task_label)
+
+        self.close_button = QPushButton("✕", self.header_widget)
+        self.close_button.setFixedSize(30, 30)
+        self.close_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.close_button.setStyleSheet(
+            """
+            QPushButton {
+                background-color: rgba(255, 255, 255, 0.2);
+                color: white;
+                border: none;
+                border-radius: 15px;
+                font-size: 16px;
+                font-weight: bold;
+            }
+            QPushButton:hover {
+                background-color: rgba(255, 0, 0, 0.7);
+            }
+        """
+        )
+        self.close_button.clicked.connect(self._on_close_clicked)
+        layout.addWidget(self.close_button)
+
+        layout.addStretch()
+
+        self.header_widget.adjustSize()
+
+    def _on_close_clicked(self):
+        self.hide()
+        if self.on_close_callback:
+            self.on_close_callback()
+
+    def set_task_name(self, name):
+        self.task_name = name if name else ""
+        self.task_label.setText(self.task_name)
+        self.header_widget.adjustSize()
+        self._position_header()
+
+    def _position_header(self):
+        screen = QApplication.primaryScreen()
+        if screen:
+            screen_geometry = screen.geometry()
+            header_width = self.header_widget.sizeHint().width()
+            x = (screen_geometry.width() - header_width) // 2
+            y = self.border_width + 5
+            self.header_widget.move(x, y)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._position_header()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        rect = self.rect()
+        border_rect = QRect(
+            rect.x() + self.border_width // 2,
+            rect.y() + self.border_width // 2,
+            rect.width() - self.border_width,
+            rect.height() - self.border_width,
+        )
+
+        pen = QPen(self.border_color)
+        pen.setWidth(self.border_width)
+        painter.setPen(pen)
+        painter.drawRect(border_rect)
+
+        painter.end()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._position_header()

--- a/install.command
+++ b/install.command
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+OPEN_APP=false
+if [[ "${1:-}" == "--open" ]]; then
+    OPEN_APP=true
+fi
+
 log() { printf "[%s] %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
 cleanup() {
   if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
@@ -29,5 +34,12 @@ log "Changed to script directory: $(pwd)"
 
 make setup
 
+log "=== Step 3: Building and installing the application ==="
+make install-macosx
+
 log "✅ Installation complete! The application is now in ~/Applications."
+if [[ "$OPEN_APP" == "true" ]]; then
+    log "Opening TaskRider.app..."
+    open "$HOME/Applications/TaskRider.app"
+fi
 log "✅ You can close this terminal window."

--- a/progress/focus-border-mode.md
+++ b/progress/focus-border-mode.md
@@ -124,3 +124,50 @@ Increased top border to 45 pixels to clear the Mac notch, ensuring the task name
 
 ### Close Button Timer Stop
 The close button now stops the timer by calling `ManageTimerController.toggle_timer()` instead of just hiding the overlay. This ensures the main window reflects the correct timer state when it reappears.
+
+### Persistent Focus Border Across Application Switches
+Implemented macOS-specific window properties to ensure the focus border remains visible when switching to other applications.
+
+**Problem:**
+On macOS, windows with `Qt.WindowType.WindowStaysOnTopHint` still get hidden when the application loses focus. This caused the focus border to disappear when switching to another app.
+
+**Solution:**
+Added `_setup_macos_window_properties()` method that configures the underlying NSWindow with special collection behaviors using the Objective-C runtime via ctypes.
+
+**Technical Implementation:**
+```python
+def _setup_macos_window_properties(self):
+    # Uses ctypes to call Objective-C runtime directly
+    from ctypes import c_void_p, CDLL, c_bool, c_uint
+
+    # Get the NSWindow from the Qt widget's winId
+    view_id = int(self.winId())
+    objc = CDLL(None)
+
+    # Get the window from the view
+    window = objc.objc_msgSend(view_id, window_sel)
+
+    if window:
+        # Prevent window from hiding on app deactivation
+        objc.objc_msgSend(window, set_hides_on_deactivate_sel, False)
+
+        # Set collection behavior to appear on all Spaces and full-screen apps
+        collection_behavior = (
+            NSWindowCollectionBehaviorCanJoinAllSpaces  # 1 << 0
+            | NSWindowCollectionBehaviorFullScreenAuxiliary  # 1 << 8
+        )
+        objc.objc_msgSend(window, set_collection_behavior_sel, collection_behavior)
+```
+
+**Key macOS Window Properties Set:**
+- `hidesOnDeactivate = False` - Prevents the window from being hidden when the application becomes inactive
+- `collectionBehavior = CanJoinAllSpaces | FullScreenAuxiliary` - Allows the window to:
+  - Appear on all macOS Spaces (virtual desktops)
+  - Float above full-screen applications
+
+**Dependencies:**
+- Uses existing `pyobjc` dependency in the project
+- ctypes is part of Python standard library
+
+**Timing:**
+The method is called in `showEvent()` after the widget is shown, ensuring the NSWindow exists before attempting to set its properties. A flag `_macos_properties_set` prevents redundant configuration.

--- a/progress/focus-border-mode.md
+++ b/progress/focus-border-mode.md
@@ -1,0 +1,113 @@
+# Focus Border Mode
+
+## Overview
+
+When a user starts a task, the main TaskRider window hides and a full-screen focus border appears around the screen with the task name displayed at the top center. This creates a distraction-free environment while keeping the user aware of their current task.
+
+## Feature Behavior
+
+1. **On Task Start**:
+   - Main TaskRider window hides
+   - Full-screen border overlay appears
+   - Current task name displays at top center
+   - Close button (x) appears next to task name
+
+2. **On Close Button Click**:
+   - Border overlay hides
+   - Main TaskRider window reappears
+
+3. **On Timer Pause**:
+   - Border overlay hides
+   - Main TaskRider window reappears
+
+## Technical Implementation
+
+### New File: `app/widgets/focus_border_widget.py`
+
+A new `FocusBorderWidget` class that extends `QWidget`:
+
+```python
+class FocusBorderWidget(QWidget):
+    def __init__(self, on_close_callback=None):
+        # Frameless, stay-on-top, tool window
+        # Translucent background for border-only appearance
+```
+
+**Key Attributes:**
+- `border_color`: QColor(0, 122, 255) - Blue accent color
+- `border_width`: 8 pixels - Thick enough to be noticeable
+
+**Window Flags:**
+- `Qt.WindowType.FramelessWindowHint` - No window decorations
+- `Qt.WindowType.WindowStaysOnTopHint` - Always visible
+- `Qt.WindowType.Tool` - Doesn't appear in taskbar
+
+**Widget Attributes:**
+- `Qt.WidgetAttribute.WA_TranslucentBackground` - Transparent interior
+- `Qt.WidgetAttribute.WA_ShowWithoutActivating` - Doesn't steal focus
+
+**Components:**
+- `task_label`: QLabel displaying the task name (18pt bold, white)
+- `close_button`: QPushButton with (x) symbol, circular, hover effect
+- `header_widget`: Container widget for task name and close button
+
+**Methods:**
+- `_setup_header()`: Creates the header with centered task name and close button
+- `_on_close_clicked()`: Handles close button click, triggers callback
+- `set_task_name(name)`: Updates the displayed task name
+- `_position_header()`: Centers header at top of screen
+- `paintEvent()`: Draws the border rectangle using QPainter
+- `showEvent()`: Repositions header when widget shows
+- `resizeEvent()`: Repositions header on resize
+
+### Modified File: `app/controllers/overlay_controller.py`
+
+Updated `OverlayController` to manage the focus border:
+
+**Changes:**
+- Removed old `Overlay` widget dependency
+- Added `FocusBorderWidget` instance
+- Connected existing signals to new behavior
+
+**Methods:**
+- `display_overlay()`: Shows focus border, hides main window
+- `hide_overlay()`: Hides focus border, shows main window
+- `on_focus_border_closed()`: Callback for close button, triggers hide
+
+## Signal Flow
+
+```
+User clicks Start
+    ↓
+ManageTimerController.toggle_timer()
+    ↓
+app_events.timer_started.emit()
+    ↓
+OverlayController.display_overlay()
+    ↓
+- Get top task from data
+- Set task name on focus border
+- Show focus border
+- Hide main window
+```
+
+## File Structure
+
+```
+app/
+├── controllers/
+│   └── overlay_controller.py  (modified)
+└── widgets/
+    └── focus_border_widget.py  (new)
+```
+
+## Branch
+
+`feature/focus-border-mode`
+
+## Future Enhancements (Potential)
+
+- Configurable border color/thickness
+- Optional timer display in border
+- Keyboard shortcut to toggle border
+- Multi-monitor support (border on active monitor only)

--- a/progress/focus-border-mode.md
+++ b/progress/focus-border-mode.md
@@ -112,11 +112,12 @@ app/
 - Configurable border color/thickness
 - Optional timer display in border
 - Keyboard shortcut to toggle border
-- Multi-monitor support (border on active monitor only)
 
-### Multi-Monitor Support
+## Recent Updates
 
-The focus border now appears on all connected monitors simultaneously:
+### Multi-Monitor Support (Current)
+
+The focus border now appears on all connected monitors simultaneously.
 
 **Implementation:**
 - `OverlayController` creates a `FocusBorderWidget` for each screen via `QApplication.screens()`
@@ -135,10 +136,6 @@ The focus border now appears on all connected monitors simultaneously:
 - Added `target_screen` constructor parameter
 - Uses target screen geometry instead of primary screen
 - Renamed internal `screen` attribute to `_target_screen` to avoid QWidget.screen() conflict
-
-## Recent Updates
-
-### Multi-Monitor Support (Current)
 
 ### Task Label Background
 Added semi-transparent black background (`rgba(0, 0, 0, 0.7)`) with rounded corners and padding to the task label for better visibility against any screen content.

--- a/progress/focus-border-mode.md
+++ b/progress/focus-border-mode.md
@@ -114,7 +114,31 @@ app/
 - Keyboard shortcut to toggle border
 - Multi-monitor support (border on active monitor only)
 
+### Multi-Monitor Support
+
+The focus border now appears on all connected monitors simultaneously:
+
+**Implementation:**
+- `OverlayController` creates a `FocusBorderWidget` for each screen via `QApplication.screens()`
+- `FocusBorderWidget` accepts an optional `target_screen` parameter to position on specific screens
+- Monitors screen configuration changes via `QApplication.screenAdded` and `QApplication.screenRemoved` signals
+- All borders display the same task name and close synchronously
+
+**Changes to `OverlayController`:**
+- Replaced single `focus_border` with `focus_borders` list
+- Added `_create_focus_borders()` to initialize widgets for all screens
+- Added `_handle_screen_added()` to create border for new monitors
+- Added `_handle_screen_removed()` to clean up borders for removed monitors
+- Updated `display_overlay()` and `hide_overlay()` to manage all borders
+
+**Changes to `FocusBorderWidget`:**
+- Added `target_screen` constructor parameter
+- Uses target screen geometry instead of primary screen
+- Renamed internal `screen` attribute to `_target_screen` to avoid QWidget.screen() conflict
+
 ## Recent Updates
+
+### Multi-Monitor Support (Current)
 
 ### Task Label Background
 Added semi-transparent black background (`rgba(0, 0, 0, 0.7)`) with rounded corners and padding to the task label for better visibility against any screen content.

--- a/progress/focus-border-mode.md
+++ b/progress/focus-border-mode.md
@@ -13,6 +13,7 @@ When a user starts a task, the main TaskRider window hides and a full-screen foc
    - Close button (x) appears next to task name
 
 2. **On Close Button Click**:
+   - Timer stops (via `toggle_timer()`)
    - Border overlay hides
    - Main TaskRider window reappears
 
@@ -35,7 +36,8 @@ class FocusBorderWidget(QWidget):
 
 **Key Attributes:**
 - `border_color`: QColor(0, 122, 255) - Blue accent color
-- `border_width`: 8 pixels - Thick enough to be noticeable
+- `border_width`: 8 pixels - Side and bottom border thickness
+- `top_border_width`: 45 pixels - Thicker top border to clear Mac notch
 
 **Window Flags:**
 - `Qt.WindowType.FramelessWindowHint` - No window decorations
@@ -47,7 +49,7 @@ class FocusBorderWidget(QWidget):
 - `Qt.WidgetAttribute.WA_ShowWithoutActivating` - Doesn't steal focus
 
 **Components:**
-- `task_label`: QLabel displaying the task name (18pt bold, white)
+- `task_label`: QLabel displaying the task name (18pt bold, white text on semi-transparent black background with rounded corners and padding)
 - `close_button`: QPushButton with (x) symbol, circular, hover effect
 - `header_widget`: Container widget for task name and close button
 
@@ -72,7 +74,7 @@ Updated `OverlayController` to manage the focus border:
 **Methods:**
 - `display_overlay()`: Shows focus border, hides main window
 - `hide_overlay()`: Hides focus border, shows main window
-- `on_focus_border_closed()`: Callback for close button, triggers hide
+- `on_focus_border_closed()`: Callback for close button, stops timer via `toggle_timer()`
 
 ## Signal Flow
 
@@ -111,3 +113,14 @@ app/
 - Optional timer display in border
 - Keyboard shortcut to toggle border
 - Multi-monitor support (border on active monitor only)
+
+## Recent Updates
+
+### Task Label Background
+Added semi-transparent black background (`rgba(0, 0, 0, 0.7)`) with rounded corners and padding to the task label for better visibility against any screen content.
+
+### Mac Notch Support
+Increased top border to 45 pixels to clear the Mac notch, ensuring the task name and close button appear below the notch. Side and bottom borders remain 8 pixels.
+
+### Close Button Timer Stop
+The close button now stops the timer by calling `ManageTimerController.toggle_timer()` instead of just hiding the overlay. This ensures the main window reflects the correct timer state when it reappears.


### PR DESCRIPTION
When starting a task, hide main window and show a full-screen border with task name and close button. Clicking (x) or pausing restores the main window.